### PR TITLE
feat: add support for new Billing on Arbitrum

### DIFF
--- a/abis/Billing.json
+++ b/abis/Billing.json
@@ -3,7 +3,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_gateway",
+        "name": "_collector",
         "type": "address"
       },
       {
@@ -14,6 +14,11 @@
       {
         "internalType": "address",
         "name": "_governor",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l2TokenGateway",
         "type": "address"
       }
     ],
@@ -26,11 +31,68 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "newGateway",
+        "name": "collector",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "CollectorUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientBalanceForRemoval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l1BillingConnector",
         "type": "address"
       }
     ],
-    "name": "GatewayUpdated",
+    "name": "L1BillingConnectorUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l2TokenGateway",
+        "type": "address"
+      }
+    ],
+    "name": "L2TokenGatewayUpdated",
     "type": "event"
   },
   {
@@ -115,7 +177,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "user",
+        "name": "from",
         "type": "address"
       },
       {
@@ -198,16 +260,21 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "gateway",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        "internalType": "address[]",
+        "name": "_to",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amount",
+        "type": "uint256[]"
       }
     ],
-    "stateMutability": "view",
+    "name": "addToMany",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -221,6 +288,74 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isCollector",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1BillingConnector",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2TokenGateway",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onTokenTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -286,7 +421,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_user",
+        "name": "_to",
         "type": "address"
       },
       {
@@ -296,6 +431,29 @@
       }
     ],
     "name": "remove",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeFromL1",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -327,11 +485,42 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_newGateway",
+        "name": "_collector",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setCollector",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1BillingConnector",
         "type": "address"
       }
     ],
-    "name": "setGateway",
+    "name": "setL1BillingConnector",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l2TokenGateway",
+        "type": "address"
+      }
+    ],
+    "name": "setL2TokenGateway",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,5 +1,5 @@
 {
     "network": "arbitrum-one",
-    "blockNumber": 0,
-    "addressBilling": "0x70D070D070D070D070D070D070D070D070D070D0"
+    "blockNumber": 42472346,
+    "addressBilling": "0x1B07D3344188908Fb6DEcEac381f3eE63C48477a"
 }

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,9 +1,5 @@
 {
-    "network": "matic",
-    "blockNumber": 17803962,
-    "addressBilling": "0x10829DB618E6F520Fa3A01c75bC6dDf8722fA9fE",
-    "addressGRT": "0x5fe2B58c013d7601147DcdD68C143A77499f5531",
-    "blockNumberOld": 16375500,
-    "addressBillingOld": "0xa382f75b375d6a07bfd1af99d4383c6e1d1c4004",
-    "useOld": true
+    "network": "arbitrum-one",
+    "blockNumber": 0,
+    "addressBilling": "0x70D070D070D070D070D070D070D070D070D070D0"
 }

--- a/config/testnet.json
+++ b/config/testnet.json
@@ -1,5 +1,5 @@
 {
-    "network": "arbitrum-goerli",
-    "blockNumber": 500177,
-    "addressBilling": "0x10CEF86258b3327fA43B4e9bDEB4c7f4f05ad5E6"
+  "network": "arbitrum-goerli",
+  "blockNumber": 1149268,
+  "addressBilling": "0x2da5DF23869B05b6641C91297b7025029112abA7"
 }

--- a/config/testnet.json
+++ b/config/testnet.json
@@ -1,7 +1,5 @@
 {
-    "network": "mumbai",
-    "blockNumber": 14933000,
-    "addressBilling": "0xccbCD50214832EA50C426631187b0b646615E92f",
-    "addressGRT": "0xfe4F5145f6e09952a5ba9e956ED0C25e3Fa4c7F1",
-    "useOld": false
+    "network": "arbitrum-goerli",
+    "blockNumber": 500177,
+    "addressBilling": "0x10CEF86258b3327fA43B4e9bDEB4c7f4f05ad5E6"
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,7 +5,7 @@ type Billing @entity {
   "Set to 1"
   id: ID!
   "Address of the collectors"
-  collectors: [Bytes!]!
+  collectors: [Collector!]! @derivedFrom(field: "billing")
   "Address of the governor"
   governor: Bytes!
   "[CUMULATIVE] Total amount of tokens added"
@@ -26,7 +26,7 @@ type Billing @entity {
 Curator Name Signal for a single Subgraph
 """
 type User @entity {
-  "Polygon address"
+  "EVM address"
   id: ID!
   "Balance of the user in the Billing contract"
   billingBalance: BigInt!
@@ -45,6 +45,16 @@ type User @entity {
 
   "[DEPRECATED] Total polygonGRT balance"
   polygonGRTBalance: BigInt!
+}
+
+"""
+A collector authorized to pull tokens
+"""
+type Collector @entity {
+  "EVM address"
+  id: ID!
+  "Billing contract"
+  billing: Billing!
 }
 
 """
@@ -150,7 +160,7 @@ type BillingDailyData @entity {
   "[CURRENT] Total amount of currently available balance (totalTokensAdded - totalTokensPulled - totalTokensRemoved)"
   totalCurrentBalance: BigInt!
   "Address of the collectors"
-  collectors: [Bytes!]!
+  collectors: [Collector!]!
   "Address of the governor"
   governor: Bytes!
   "[DELTA] Chage in total tokens added since the last DailyData point"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,8 +4,8 @@ Billing holds global variables
 type Billing @entity {
   "Set to 1"
   id: ID!
-  "Address of the gateway"
-  gateway: Bytes!
+  "Address of the collectors"
+  collectors: [Bytes!]!
   "Address of the governor"
   governor: Bytes!
   "[CUMULATIVE] Total amount of tokens added"
@@ -96,7 +96,7 @@ type TokensRemoved implements Transaction @entity {
 }
 
 """
-TokensPulled Transaction. Where the gateway pulls tokens from the user
+TokensPulled Transaction. Where a collector pulls tokens from the user
 """
 type TokensPulled implements Transaction @entity {
   id: ID!
@@ -112,6 +112,20 @@ enum TransactionType {
   TokensAdded
   TokensRemoved
   TokensPulled
+}
+
+"""
+InsufficientBalanceForRemoval event, where a user tried to remove funds from L1 but the balance was insufficient
+"""
+type InsufficientBalanceForRemoval @entity {
+  id: ID!
+  hash: Bytes!
+  blockNumber: Int!
+  timestamp: Int!
+  user: User!
+  amount: BigInt!
+  "User that the tokens are tried to be withdrawn to"
+  to: Bytes!
 }
 
 # Daily data entities
@@ -135,8 +149,8 @@ type BillingDailyData @entity {
   totalTokensRemoved: BigInt!
   "[CURRENT] Total amount of currently available balance (totalTokensAdded - totalTokensPulled - totalTokensRemoved)"
   totalCurrentBalance: BigInt!
-  "Address of the gateway"
-  gateway: Bytes!
+  "Address of the collectors"
+  collectors: [Bytes!]!
   "Address of the governor"
   governor: Bytes!
   "[DELTA] Chage in total tokens added since the last DailyData point"

--- a/schema.graphql
+++ b/schema.graphql
@@ -55,6 +55,7 @@ type Collector @entity {
   id: ID!
   "Billing contract"
   billing: Billing!
+  enabled: Boolean!
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -159,8 +159,6 @@ type BillingDailyData @entity {
   totalTokensRemoved: BigInt!
   "[CURRENT] Total amount of currently available balance (totalTokensAdded - totalTokensPulled - totalTokensRemoved)"
   totalCurrentBalance: BigInt!
-  "Address of the collectors"
-  collectors: [Collector!]!
   "Address of the governor"
   governor: Bytes!
   "[DELTA] Chage in total tokens added since the last DailyData point"

--- a/src/mappings/billing.ts
+++ b/src/mappings/billing.ts
@@ -109,7 +109,9 @@ export function handleTokensRemoved(event: RemovedEvent): void {
 }
 
 /**
- * @dev Handle the Tokens Removed event
+ * @dev Handle the Insufficient Balance for Removal event
+ * This doesn't affect a user's transactions but we surface it
+ * in case it becomes useful to show it in the UI.
  */
  export function handleInsufficientBalanceForRemoval(event: InsufficientBalanceForRemovalEvent): void {
 

--- a/src/mappings/billing.ts
+++ b/src/mappings/billing.ts
@@ -14,6 +14,7 @@ import {
   createOrLoadUser,
   getAndUpdateBillingDailyData,
   getAndUpdateUserDailyData,
+  DEFAULT_BILLING_ID,
 } from './helpers'
 
 /**
@@ -23,12 +24,12 @@ export function handleCollectorUpdated(event: CollectorUpdated): void {
   let collector = Collector.load(event.params.collector.toHexString())
   if (collector == null && event.params.enabled) {
     collector = new Collector(event.params.collector.toHexString())
-    collector.billing = '1'
+    collector.billing = DEFAULT_BILLING_ID
     collector.save()
   } else if (collector != null && !event.params.enabled) {
     store.remove('Collector', collector.id)
   }
-  let billing = getBilling(event.address)
+  const billing = getBilling(event.address)
   getAndUpdateBillingDailyData(billing, event.block.timestamp)
   billing.save()
 }

--- a/src/mappings/billing.ts
+++ b/src/mappings/billing.ts
@@ -28,13 +28,12 @@ import {
  */
 export function handleCollectorUpdated(event: CollectorUpdated): void {
   let collector = Collector.load(event.params.collector.toHexString())
-  if (collector == null && event.params.enabled) {
+  if (collector == null) {
     collector = new Collector(event.params.collector.toHexString())
     collector.billing = DEFAULT_BILLING_ID
-    collector.save()
-  } else if (collector != null && !event.params.enabled) {
-    store.remove('Collector', collector.id)
   }
+  collector.enabled = event.params.enabled
+  collector.save()
   const billing = getBilling(event.address)
   getAndUpdateBillingDailyData(billing, event.block.timestamp)
   billing.save()

--- a/src/mappings/billing.ts
+++ b/src/mappings/billing.ts
@@ -1,4 +1,10 @@
-import { TokensAdded, TokensRemoved, TokensPulled, InsufficientBalanceForRemoval, Collector } from '../types/schema'
+import {
+  TokensAdded,
+  TokensRemoved,
+  TokensPulled,
+  InsufficientBalanceForRemoval,
+  Collector,
+} from '../types/schema'
 import { store } from '@graphprotocol/graph-ts'
 import {
   TokensAdded as AddedEvent,
@@ -114,8 +120,9 @@ export function handleTokensRemoved(event: RemovedEvent): void {
  * This doesn't affect a user's transactions but we surface it
  * in case it becomes useful to show it in the UI.
  */
- export function handleInsufficientBalanceForRemoval(event: InsufficientBalanceForRemovalEvent): void {
-
+export function handleInsufficientBalanceForRemoval(
+  event: InsufficientBalanceForRemovalEvent,
+): void {
   let ev = new InsufficientBalanceForRemoval(
     event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString()),
   )

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -14,7 +14,6 @@ export function getBilling(eventAddress: Address): Billing {
     billing = new Billing(DEFAULT_BILLING_ID)
     let contract = BillingContract.bind(eventAddress)
     billing.governor = contract.governor()
-    billing.collectors = []
     billing.save()
   }
 
@@ -56,7 +55,6 @@ export function getAndUpdateBillingDailyData(entity: Billing, timestamp: BigInt)
   dailyData.totalTokensPulled = entity.totalTokensPulled
   dailyData.totalTokensRemoved = entity.totalTokensRemoved
   dailyData.totalCurrentBalance = entity.totalCurrentBalance
-  dailyData.collectors = entity.collectors
   dailyData.governor = entity.governor
 
   if (entity.previousDailyDataEntity != null) {

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -4,14 +4,14 @@ import { BigInt, Address } from '@graphprotocol/graph-ts'
 
 export const LAUNCH_DAY = 18613 // 1608163200 / 86400. 1608163200 = 17 Dec 2020 00:00:00 GMT
 export const SECONDS_PER_DAY = 86400
-
+export const DEFAULT_BILLING_ID = '1'
 /**
  * @dev Helper function to load Billing
  */
 export function getBilling(eventAddress: Address): Billing {
-  let billing = Billing.load('1')
+  let billing = Billing.load(DEFAULT_BILLING_ID)
   if (billing == null) {
-    billing = new Billing('1')
+    billing = new Billing(DEFAULT_BILLING_ID)
     let contract = BillingContract.bind(eventAddress)
     billing.governor = contract.governor()
     billing.collectors = []

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -55,7 +55,7 @@ export function getAndUpdateBillingDailyData(entity: Billing, timestamp: BigInt)
   dailyData.totalTokensPulled = entity.totalTokensPulled
   dailyData.totalTokensRemoved = entity.totalTokensRemoved
   dailyData.totalCurrentBalance = entity.totalCurrentBalance
-  dailyData.gateway = entity.gateway
+  dailyData.collectors = entity.collectors
   dailyData.governor = entity.governor
 
   if (entity.previousDailyDataEntity != null) {

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -14,6 +14,7 @@ export function getBilling(eventAddress: Address): Billing {
     billing = new Billing('1')
     let contract = BillingContract.bind(eventAddress)
     billing.governor = contract.governor()
+    billing.collectors = []
     billing.save()
   }
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -22,12 +22,13 @@ dataSources:
         - TokensAdded
         - TokensRemoved
         - TokensPulled
+        - InsufficientBalanceForRemoval
       abis:
         - name: Billing
           file: ./abis/Billing.json
       eventHandlers:
-        - event: GatewayUpdated(indexed address)
-          handler: handleGatewayUpdated
+        - event: CollectorUpdated(indexed address,bool)
+          handler: handleCollectorUpdated
         - event: NewOwnership(indexed address,indexed address)
           handler: handleNewOwnership
         - event: TokensAdded(indexed address,uint256)
@@ -36,37 +37,5 @@ dataSources:
           handler: handleTokensRemoved
         - event: TokensPulled(indexed address,uint256)
           handler: handleTokensPulled
-{{#useOld}}
-  - kind: ethereum/contract
-    name: BillingOld
-    network: {{network}}
-    source:
-      address: "{{addressBillingOld}}"
-      abi: Billing
-      startBlock: {{blockNumberOld}}
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      file: ./src/mappings/billing.ts
-      entities:
-        - Billing
-        - User
-        - TokensAdded
-        - TokensRemoved
-        - TokensPulled
-      abis:
-        - name: Billing
-          file: ./abis/Billing.json
-      eventHandlers:
-        - event: GatewayUpdated(indexed address)
-          handler: handleGatewayUpdated
-        - event: NewOwnership(indexed address,indexed address)
-          handler: handleNewOwnership
-        - event: TokensAdded(indexed address,uint256)
-          handler: handleTokensAdded
-        - event: TokensRemoved(indexed address,indexed address,uint256)
-          handler: handleTokensRemoved
-        - event: TokensPulled(indexed address,uint256)
-          handler: handleTokensPulled
-{{/useOld}}
+        - event: InsufficientBalanceForRemoval(indexed address,indexed address,uint256)
+          handler: handleInsufficientBalanceForRemoval

--- a/tests/billing-scaffolding.ts
+++ b/tests/billing-scaffolding.ts
@@ -199,6 +199,7 @@ export function createEmptyBilling(): Billing {
 
   let collector = new Collector('0x1111111111111111111111111111111111111112')
   collector.billing = billing.id
+  collector.enabled = true
   collector.save()
 
   return Billing.load('1')!

--- a/tests/billing.test.ts
+++ b/tests/billing.test.ts
@@ -46,12 +46,19 @@ test('Collector update', () => {
 
   billing = Billing.load('1')!
   assertEqualCollectorArrays(billing.collectors, [oldCollectorAddressString, newCollectorAddressString])
+
+  assert.fieldEquals('Collector', oldCollectorAddressString, 'enabled', 'true')
+  assert.fieldEquals('Collector', newCollectorAddressString, 'enabled', 'true')
+
   collectorUpdatedEvent = createCollectorUpdated(oldCollectorAddressString, false)
 
   handleCollectorUpdated(collectorUpdatedEvent)
 
   billing = Billing.load('1')!
-  assertEqualCollectorArrays(billing.collectors, [newCollectorAddressString])
+  assertEqualCollectorArrays(billing.collectors, [oldCollectorAddressString, newCollectorAddressString])
+
+  assert.fieldEquals('Collector', oldCollectorAddressString, 'enabled', 'false')
+  assert.fieldEquals('Collector', newCollectorAddressString, 'enabled', 'true')
   clearStore()
 })
 

--- a/tests/billing.test.ts
+++ b/tests/billing.test.ts
@@ -35,11 +35,11 @@ function assertEqualCollectorArrays(actualArray: Array<String>, expectedArray: A
  */
 test('Collector update', () => {
   let billing = createEmptyBilling()
-  let oldCollectorAddressString = '0x1111111111111111111111111111111111111112'
+  const oldCollectorAddressString = '0x1111111111111111111111111111111111111112'
   
   assertEqualCollectorArrays(billing.collectors, [oldCollectorAddressString])
 
-  let newCollectorAddressString = '0x0101010101010101010101010101010101010101'
+  const newCollectorAddressString = '0x0101010101010101010101010101010101010101'
   let collectorUpdatedEvent = createCollectorUpdated(newCollectorAddressString, true)
 
   handleCollectorUpdated(collectorUpdatedEvent)
@@ -202,16 +202,16 @@ test('Fully remove tokens', () => {
  */
 test('Reporting insufficient balance for removal', () => {
   createEmptyBilling()
-  let userAddress = '0x0101010101010101010101010101010101010101'
-  let toAddress = '0x0101010101010101010101010101010101010102'
-  let grtAmountString = '10000000000000000000'
-  let grtAmount = BigInt.fromString(grtAmountString)
+  const userAddress = '0x0101010101010101010101010101010101010101'
+  const toAddress = '0x0101010101010101010101010101010101010102'
+  const grtAmountString = '10000000000000000000'
+  const grtAmount = BigInt.fromString(grtAmountString)
 
-  let insufficientBalanceEvent = createInsufficientBalanceEvent(userAddress, toAddress, grtAmount)
+  const insufficientBalanceEvent = createInsufficientBalanceEvent(userAddress, toAddress, grtAmount)
 
   handleInsufficientBalanceForRemoval(insufficientBalanceEvent)
 
-  let id = insufficientBalanceEvent.transaction.hash.toHexString().concat(insufficientBalanceEvent.transactionLogIndex.toString())
+  const id = insufficientBalanceEvent.transaction.hash.toHexString().concat(insufficientBalanceEvent.transactionLogIndex.toString())
   assert.fieldEquals('InsufficientBalanceForRemoval', id, 'user', userAddress)
   assert.fieldEquals('InsufficientBalanceForRemoval', id, 'to', toAddress)
   assert.fieldEquals('InsufficientBalanceForRemoval', id, 'amount', grtAmountString)


### PR DESCRIPTION
This will remove references to the Billing contract(s) on Polygon, and replace them with the new ones on Arbitrum Goerli and Arbitrum One.

For now it's targeting the scratch testnet deployment from https://github.com/edgeandnode/billing-contracts/pull/27 - I will replace that with the proper testnet deployment when it's done, and also add the Arbitrum One deployment when we have one.